### PR TITLE
Use new BMI functions for unstructured grids

### DIFF
--- a/bmi.h
+++ b/bmi.h
@@ -62,8 +62,7 @@ typedef struct {
   int (* get_grid_y)(void *, int, double *);
   int (* get_grid_z)(void *, int, double *);
 
-  int (* get_grid_cell_count)(void *, int, int *);
-  int (* get_grid_point_count)(void *, int, int *);
+  int (* get_grid_face_count)(void *, int, int *);
   int (* get_grid_vertex_count)(void *, int, int *);
 
   int (* get_grid_connectivity)(void *, int, int *);


### PR DESCRIPTION
To match the latest BMI specification in [bmi-forum/babelizer](https://github.com/bmi-forum/babelizer), I renamed `get_grid_cell_count` to `get_grid_face_count`. Further, the `get_grid_point_count` function is obsolete, so I removed it. Neither of these functions were implemented in the HydroTrend BMI, so there shouldn't be any changes to its behavior.