### PR TITLE
Check that the input configuration file is not a null string

### DIFF
--- a/bmi_hydrotrend.c
+++ b/bmi_hydrotrend.c
@@ -147,7 +147,7 @@ initialize(const char * file, void **handle)
 
     *handle = NULL;
 
-    if (file) {
+    if (file && file[0] != '\0') {
       FILE * fp = fopen (file, "r");
 
       if (fp) {


### PR DESCRIPTION
This change (created by @mcflugen) brings the Hydrotrend BMI in line with the expected input to the `initialize` method created for the component by PyMT.

Now, you can call the Hydrotrend component from PyMT with:

```python
from pymt.components import Hydrotrend

component = Hydrotrend()
cfg = component.setup('.')
component.initialize(*cfg)
component.update()
component.finalize()
```