### PR TITLE
Build on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,12 @@ elseif (NOT LIB_M)
   target_link_libraries(run_hydrotrend bmi_hydrotrend-static)
 endif (LIB_M)
 
-install(TARGETS run_hydrotrend DESTINATION bin RENAME hydrotrend COMPONENT hydrotrend)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/run_hydrotrend${CMAKE_EXECUTABLE_SUFFIX}
+  DESTINATION bin
+  RENAME hydrotrend
+  COMPONENT hydrotrend
+)
 
 ########### Install files ###############
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.6)
+include(CheckIncludeFile)
 
 project( hydrotrend )
 
@@ -31,6 +32,9 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/hydrotrend.pc.cmake
                 ${CMAKE_CURRENT_SOURCE_DIR}/hydrotrend.pc )
 
 ########### libhydrotrend ###############
+
+check_include_file(getopt.h WITH_GETOPT)
+check_include_file(unistd.h WITH_UNISTD)
 
 set(hydrotrend_lib_SRCS
    bmi_hydrotrend.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif (LIB_M)
 install(
   PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_hydrotrend${CMAKE_EXECUTABLE_SUFFIX}
   DESTINATION bin
-  RENAME hydrotrend
+  RENAME hydrotrend${CMAKE_EXECUTABLE_SUFFIX}
   COMPONENT hydrotrend
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/hydrotrend.pc.cmake
 check_include_file(getopt.h WITH_GETOPT)
 check_include_file(unistd.h WITH_UNISTD)
 
+if (WITH_GETOPT)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWITH_GETOPT")
+endif (WITH_GETOPT)
+
+if (WITH_UNISTD)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWITH_UNISTD")
+endif (WITH_UNISTD)
+
 set(hydrotrend_lib_SRCS
    bmi_hydrotrend.c
    hydrotrend_irf.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif (WITH_GETOPT)
 if (WITH_UNISTD)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DWITH_UNISTD")
 endif (WITH_UNISTD)
+find_library(LIB_M m)
 
 set(hydrotrend_lib_SRCS
    bmi_hydrotrend.c
@@ -98,8 +99,9 @@ install(FILES bmi.h bmi_hydrotrend.h DESTINATION include/hydrotrend)
 set(hydrotrend_SRCS hydrotrend_main.c)
 
 add_executable(run_hydrotrend ${hydrotrend_SRCS})
-
-target_link_libraries(run_hydrotrend bmi_hydrotrend-static m)
+if (LIB_M)
+  target_link_libraries(run_hydrotrend bmi_hydrotrend-static m)
+endif (LIB_M)
 
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_hydrotrend
         DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ elseif (NOT LIB_M)
 endif (LIB_M)
 
 install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/run_hydrotrend${CMAKE_EXECUTABLE_SUFFIX}
+  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_hydrotrend${CMAKE_EXECUTABLE_SUFFIX}
   DESTINATION bin
   RENAME hydrotrend
   COMPONENT hydrotrend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,10 +106,7 @@ elseif (NOT LIB_M)
   target_link_libraries(run_hydrotrend bmi_hydrotrend-static)
 endif (LIB_M)
 
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_hydrotrend
-        DESTINATION bin
-        RENAME hydrotrend
-        COMPONENT hydrotrend)
+install(TARGETS run_hydrotrend DESTINATION bin RENAME hydrotrend COMPONENT hydrotrend)
 
 ########### Install files ###############
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/hydrotrend.pc.cmake
 
 check_include_file(getopt.h WITH_GETOPT)
 check_include_file(unistd.h WITH_UNISTD)
+find_library(LIB_M m)
 
 set(hydrotrend_lib_SRCS
    bmi_hydrotrend.c
@@ -91,7 +92,11 @@ set(hydrotrend_SRCS hydrotrend_main.c)
 
 add_executable(run_hydrotrend ${hydrotrend_SRCS})
 
-target_link_libraries(run_hydrotrend bmi_hydrotrend-static m)
+if (LIB_M)
+  target_link_libraries(run_hydrotrend bmi_hydrotrend-static m)
+elseif (NOT LIB_M)
+  target_link_libraries(run_hydrotrend bmi_hydrotrend-static)
+endif (LIB_M)
 
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_hydrotrend
         DESTINATION bin

--- a/bmi_hydrotrend.c
+++ b/bmi_hydrotrend.c
@@ -495,8 +495,8 @@ static int
 get_value_at_indices (void *self, const char *name, void *dest,
     int * inds, int len)
 {
-    void *src = NULL;
-    int itemsize = 0;
+    char *src = NULL;
+    size_t itemsize = 0;
 
     if (get_value_ptr(self, name, &src) == BMI_FAILURE)
         return BMI_FAILURE;
@@ -505,10 +505,10 @@ get_value_at_indices (void *self, const char *name, void *dest,
         return BMI_FAILURE;
 
     { /* Copy the data */
-        int i;
-        int offset;
-        void * ptr;
-        for (i=0, ptr=dest; i<len; i++, ptr+=itemsize) {
+        size_t i;
+        size_t offset;
+        char * ptr;
+        for (i=0, ptr=(char*)dest; i<len; i++, ptr+=itemsize) {
             offset = inds[i] * itemsize;
             memcpy (ptr, src + offset, itemsize);
         }
@@ -540,7 +540,7 @@ static int
 set_value_at_indices (void *self, const char *name, int * inds, int len,
     void *src)
 {
-    void * to = NULL;
+    char * to = NULL;
     int itemsize = 0;
 
     if (get_value_ptr (self, name, &to) == BMI_FAILURE)
@@ -550,10 +550,10 @@ set_value_at_indices (void *self, const char *name, int * inds, int len,
         return BMI_FAILURE;
 
     { /* Copy the data */
-        int i;
-        int offset;
-        void * ptr;
-        for (i=0, ptr=src; i<len; i++, ptr+=itemsize) {
+        size_t i;
+        size_t offset;
+        char * ptr;
+        for (i=0, ptr=(char*)src; i<len; i++, ptr+=itemsize) {
             offset = inds[i] * itemsize;
             memcpy (to + offset, ptr, itemsize);
         }

--- a/bmi_hydrotrend.c
+++ b/bmi_hydrotrend.c
@@ -37,9 +37,7 @@ get_component_name (void *self, char * name)
 
 
 #define INPUT_VAR_NAME_COUNT (0)
-static const char *input_var_names[INPUT_VAR_NAME_COUNT] = {
-
-};
+static const char **input_var_names = NULL;
 
 
 static int

--- a/hydroalloc_mem.c
+++ b/hydroalloc_mem.c
@@ -13,7 +13,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
+#ifdef WITH_UNISTD
+# include <unistd.h>
+#endif
 #include "hydroalloc_mem.h"
   
 /*      FUNCTION ALLOCATE_1D FILE */ 

--- a/hydroalloc_mem.c
+++ b/hydroalloc_mem.c
@@ -47,7 +47,6 @@ matrixalloc1D (int max_width, long size)
   if (!atemp)
     {
       perror ("matrixalloc");
-      sleep (5);
       exit (1);
     }
   return atemp;
@@ -70,7 +69,6 @@ matrixalloc2D (int max_width, int max_length, long size)
   if (!atemp)
     {
       perror ("matrixalloc");
-      sleep (5);
       exit (1);
     }
   for (i = 0; i < max_width; ++i)
@@ -79,7 +77,6 @@ matrixalloc2D (int max_width, int max_length, long size)
       if (!atemp[i])
         {
           perror ("matrixalloc");
-          sleep (5);
           exit (1);
         }
     }
@@ -103,7 +100,6 @@ matrixalloc3D (int max_width, int max_length, int max_height, long size)
   if (!atemp)
     {
       perror ("matrixalloc");
-      sleep (5);
       exit (1);
     }
   for (i = 0; i < max_width; ++i)
@@ -112,7 +108,6 @@ matrixalloc3D (int max_width, int max_length, int max_height, long size)
       if (!atemp[i])
         {
           perror ("matrixalloc");
-          sleep (5);
           exit (1);
         }
     }
@@ -123,7 +118,6 @@ matrixalloc3D (int max_width, int max_length, int max_height, long size)
         if (!atemp[i][j])
           {
             perror ("matrixalloc");
-            sleep (5);
             exit (1);
           }
       }

--- a/hydroinout.h
+++ b/hydroinout.h
@@ -26,7 +26,7 @@
  * fidtrend1    	hydroinout.h	FILE	-	annual trend file #1 id
  * fidtrend2    	hydroinout.h	FILE	-	annual trend file #2 id
  * fidtrend3	        hydroinout.h	FILE	-	annual trend file #3 id
- * outp                 hydroinout.h    FILE    -       output daily vel, wid en dep file id
+ * out_file             hydroinout.h    FILE    -       output daily vel, wid en dep file id
  * outp1                hydroinout.h    FILE    -       output daily Q file id
  * outp2                hydroinout.h    FILE    -       output daily Qs average file id
  * outp3                hydroinout.h    FILE    -       output daily Qb average file id
@@ -89,7 +89,7 @@ extern FILE **fidhyps;
 extern FILE **fidquake;
 extern FILE *fidlog;
 extern FILE *fidlapserate;
-extern FILE *outp, *outp1, *outp2, *outp3, *outp4, *outp5;
+extern FILE *out_file, *outp1, *outp2, *outp3, *outp4, *outp5;
 
 extern char title[MAXCH];
 extern char moname[12][4];

--- a/hydroopenfiles.c
+++ b/hydroopenfiles.c
@@ -129,7 +129,7 @@ hydroopenfiles ()
       strcat (ffidasc, fidasc);
       if (verbose)
         printf ("Opening %s... \n", ffidasc);
-      if ((outp = fopen (ffidasc, "w")) == NULL)
+      if ((out_file = fopen (ffidasc, "w")) == NULL)
         {
           fprintf (stderr,
                    "  HydroOpenFiles ERROR: Unable to open the discharge file %s \n",

--- a/hydrooutput.c
+++ b/hydrooutput.c
@@ -537,7 +537,7 @@ fwrite (&Csoutlet[p], sizeof (float), 1, fiddis[p]);
         if (yr == syear[0])
         {
           
-fprintf (outp, "vel(m/s) wid(m) dep(m) ");
+fprintf (out_file, "vel(m/s) wid(m) dep(m) ");
           
 fprintf (outp1, "Q(m^3/s) ");
           
@@ -554,7 +554,7 @@ if (outletmodelflag == 1)
 for (p = 0; p < maxnoutlet; p++)
               {
                 
-fprintf (outp, "vel(m/s) wid(m) dep(m) ");
+fprintf (out_file, "vel(m/s) wid(m) dep(m) ");
                 
 fprintf (outp1, "Q(m^3/s) ");
                 
@@ -566,7 +566,7 @@ fprintf (outp2, "Qs(kg/s) ");
               
 }
           
-fprintf (outp, "\n");
+fprintf (out_file, "\n");
           
 fprintf (outp1, "\n");
           
@@ -578,7 +578,7 @@ fprintf (outp2, "\n");
           
 fprintf (outp5, "\n");
 
-fprintf (outp, "--------  ------- ------- ");
+fprintf (out_file, "--------  ------- ------- ");
           
 fprintf (outp1, "--------- ");
           
@@ -595,7 +595,7 @@ if (outletmodelflag == 1)
 for (p = 0; p < maxnoutlet; p++)
               {
                 
-fprintf (outp, "--------  ------- ------- ");
+fprintf (out_file, "--------  ------- ------- ");
                 
 fprintf (outp1, "--------- ");
                 
@@ -607,7 +607,7 @@ fprintf (outp2, "-------- ");
               
 }
           
-fprintf (outp, "\n");
+fprintf (out_file, "\n");
           
 fprintf (outp1, "\n");
           
@@ -628,7 +628,7 @@ fprintf (outp5, "\n");
         for (jj = 0; jj < recperyear; jj++)
         {
           
-fprintf (outp, "%.3f\t  %.3f\t  %.3f\t  ", vel[jj], wid[jj],
+fprintf (out_file, "%.3f\t  %.3f\t  %.3f\t  ", vel[jj], wid[jj],
                     dep[jj]);
           
 fprintf (outp1, "%.3f ", vel[jj] * wid[jj] * dep[jj]);
@@ -657,7 +657,7 @@ if (outletmodelflag == 1)
 for (p = 0; p < maxnoutlet; p++)
               {
                 
-fprintf (outp, "%.3f\t  %.3f\t  %.3f\t  ", veloutlet[jj][p],
+fprintf (out_file, "%.3f\t  %.3f\t  %.3f\t  ", veloutlet[jj][p],
                           widoutlet[jj][p], depoutlet[jj][p]);
                 
 fprintf (outp1, "%.3f ",
@@ -685,7 +685,7 @@ fprintf (outp2, "%.3f ", Qsavgoutlet[jj][p]);
               
 }
           
-fprintf (outp, "\n");
+fprintf (out_file, "\n");
           
 fprintf (outp1, "\n");
           

--- a/hydrosetglobalpar.c
+++ b/hydrosetglobalpar.c
@@ -33,7 +33,7 @@ FILE **fidhyps;
 FILE **fidquake;
 FILE *fidlog;
 FILE *fidlapserate;
-FILE *outp, *outp1, *outp2, *outp3, *outp4, *outp5;
+FILE *out_file, *outp1, *outp2, *outp3, *outp4, *outp5;
 
 char title[MAXCH];
 char moname[12][4];

--- a/hydrotrend.c
+++ b/hydrotrend.c
@@ -1641,7 +1641,7 @@ fclose (fiddistot);
 if (strncmp (asciioutput, ON, 2) == 0)
     {
       
-fclose (outp);
+fclose (out_file);
       
 fclose (outp1);
       

--- a/hydrotrend_cli.c
+++ b/hydrotrend_cli.c
@@ -20,7 +20,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <getopt.h>
+#ifdef WITH_GETOPT
+# include <getopt.h>
+#endif
 
 
 #define MAXLENGTH (80)
@@ -35,6 +37,18 @@
 int is_valid_str (char *str);
 char *to_upper_str (char *str);
 
+#ifndef WITH_GETOPT
+ht_args_st *
+parse_command_line (int argc, char *argv[])
+{
+  ht_args_st *args = malloc(sizeof(ht_args_st));
+  args->in_file = strdup(HT_DEFAULT_PREFIX);
+  args->in_dir = strdup(HT_DEFAULT_IN_DIR);
+  args->out_dir = NULL;
+
+  return args;
+}
+#else
 static int verbose_flag = 0;
 static int version_flag = 0;
 static int help_flag = 0;
@@ -206,6 +220,8 @@ parse_command_line (int argc, char *argv[])
 
   return args;
 }
+#endif
+
 
 int
 is_valid_str (char *str)

--- a/hydrotrend_cli.c
+++ b/hydrotrend_cli.c
@@ -37,20 +37,15 @@
 int is_valid_str (char *str);
 char *to_upper_str (char *str);
 
+#ifndef WITH_GETOPT
 static char *help_msg[] = {
-  "Usage: hydrotrend [options] [prefix [directory]]",
+  "Usage: hydrotrend [indir [outdir]]",
   "Options:",
-  "  -V or --verbose      Be verbose",
-  "  --brief              Be terse",
-  "  -v or --version      Print version number and exit",
-  "  -?,-h or --help      Print this information and exit",
-  "  -p, --prefix=PREFIX  Use PREFIX.IN as input file",
-  "  -S, --in-dir=DIR     Path to input file(s)",
-  "  -D, --out-dir=DIR    Put output in directory DIR",
+  "  -v       Print version number and exit",
+  "  -?,-h    Print this information and exit",
   NULL
 };
 
-#ifndef WITH_GETOPT
 ht_args_st *
 parse_command_line (int argc, char *argv[])
 {
@@ -84,8 +79,20 @@ parse_command_line (int argc, char *argv[])
   }
 
   args->in_file = strdup(HT_DEFAULT_PREFIX);
-  args->in_dir = strdup(HT_DEFAULT_IN_DIR);
-  args->out_dir = NULL;
+
+  if (argc == 1) {
+    args->in_dir = strdup(".");
+    args->out_dir = strdup(".");
+  } else if (argc == 2) {
+    args->in_dir = strdup(argv[1]);
+    args->out_dir = strdup(".");
+  } else if (argc == 3 ) {
+    args->in_dir = strdup(argv[1]);
+    args->out_dir = strdup(argv[2]);
+  } else {
+    fprintf(stderr, "incorrect arguments. %s -h for help", argv[0]);
+    exit(EXIT_FAILURE);
+  }
 
   return args;
 }
@@ -103,6 +110,19 @@ static struct option ht_long_opts[] = {
   {"in-dir", required_argument, NULL, 'S'},
   {"out-dir", required_argument, NULL, 'D'},
   {NULL, 0, NULL, 0}
+};
+
+static char *help_msg[] = {
+  "Usage: hydrotrend [options] [prefix [directory]]",
+  "Options:",
+  "  -V or --verbose      Be verbose",
+  "  --brief              Be terse",
+  "  -v or --version      Print version number and exit",
+  "  -?,-h or --help      Print this information and exit",
+  "  -p, --prefix=PREFIX  Use PREFIX.IN as input file",
+  "  -S, --in-dir=DIR     Path to input file(s)",
+  "  -D, --out-dir=DIR    Put output in directory DIR",
+  NULL
 };
 
 /** Parse command line options for hydrotrend.

--- a/hydrotrend_cli.c
+++ b/hydrotrend_cli.c
@@ -37,11 +37,52 @@
 int is_valid_str (char *str);
 char *to_upper_str (char *str);
 
+static char *help_msg[] = {
+  "Usage: hydrotrend [options] [prefix [directory]]",
+  "Options:",
+  "  -V or --verbose      Be verbose",
+  "  --brief              Be terse",
+  "  -v or --version      Print version number and exit",
+  "  -?,-h or --help      Print this information and exit",
+  "  -p, --prefix=PREFIX  Use PREFIX.IN as input file",
+  "  -S, --in-dir=DIR     Path to input file(s)",
+  "  -D, --out-dir=DIR    Put output in directory DIR",
+  NULL
+};
+
 #ifndef WITH_GETOPT
 ht_args_st *
 parse_command_line (int argc, char *argv[])
 {
   ht_args_st *args = malloc(sizeof(ht_args_st));
+  int arg;
+  int help_flag = 0;
+  int version_flag = 0;
+
+  for (arg=0; arg<argc; arg++) {
+    if (strcmp(argv[arg], "-h") == 0 || strcmp(argv[arg], "-?") == 0) {
+      help_flag = 1;
+    }
+    if (strcmp(argv[arg], "-v") == 0) {
+      version_flag = 1;
+    }
+  }
+  if (help_flag) {
+    char **str;
+    for (str = help_msg; *str; str++)
+      fprintf (stdout, "%s\n", *str);
+    exit (EXIT_SUCCESS);
+  }
+
+  if (version_flag) {
+    fprintf(
+        stdout,
+        "HydroTrend version %d.%d.%d\n",
+        HT_MAJOR_VERSION, HT_MINOR_VERSION, HT_MICRO_VERSION
+    );
+    exit (EXIT_SUCCESS);
+  }
+
   args->in_file = strdup(HT_DEFAULT_PREFIX);
   args->in_dir = strdup(HT_DEFAULT_IN_DIR);
   args->out_dir = NULL;
@@ -62,19 +103,6 @@ static struct option ht_long_opts[] = {
   {"in-dir", required_argument, NULL, 'S'},
   {"out-dir", required_argument, NULL, 'D'},
   {NULL, 0, NULL, 0}
-};
-
-static char *help_msg[] = {
-  "Usage: hydrotrend [options] [prefix [directory]]",
-  "Options:",
-  "  -V or --verbose      Be verbose",
-  "  --brief              Be terse",
-  "  -v or --version      Print version number and exit",
-  "  -?,-h or --help      Print this information and exit",
-  "  -p, --prefix=PREFIX  Use PREFIX.IN as input file",
-  "  -S, --in-dir=DIR     Path to input file(s)",
-  "  -D, --out-dir=DIR    Put output in directory DIR",
-  NULL
 };
 
 /** Parse command line options for hydrotrend.

--- a/hydrotrend_irf.c
+++ b/hydrotrend_irf.c
@@ -1221,7 +1221,7 @@ hydro_finalize (state * s)
 
   if (strncmp (asciioutput, ON, 2) == 0)
     {
-      fclose (outp);
+      fclose (out_file);
       fclose (outp1);
       fclose (outp2);
       fclose (outp3);

--- a/hydroweather.c
+++ b/hydroweather.c
@@ -32,7 +32,7 @@
 #include "hydrotrend.h"
 #include "hydrornseeds.h"
 #define MAXIT (3000)
-#define swap_vec( x , i , j ) { typeof(*x) temp=x[i]; x[i]=x[j]; x[j]=temp; }
+#define swap_dbl_vec( x , i , j ) { double _temp=x[i]; x[i]=x[j]; x[j]=_temp; }
 typedef int (Cost_fcn) (double *, int);
 
 /*--------------------
@@ -249,10 +249,10 @@ anneal (double *x, int n, Cost_fcn * f, int cost_min, int jj)
       do
         j = eh_get_fuzzy_int (daystrm[jj], n - 1, jj, count);
       while (j == i);
-      swap_vec (x, i, j);
+      swap_dbl_vec (x, i, j);
       cost_after = (*f) (x, n);
       if (cost_after > cost_before)
-        swap_vec (x, i, j);
+        swap_dbl_vec (x, i, j);
     }
   while (cost_after > (double) cost_min && ++itr < max_itr);
   return x;

--- a/hydroweather.c
+++ b/hydroweather.c
@@ -308,7 +308,7 @@ cost_fcn (double *x, int n)
       else
         j[i] = 0;
       if (i > daystrm[jj])
-        k += fabs (j[i - 1] - j[i]);
+        k += abs (j[i - 1] - j[i]);
     }
   freematrix1D ((void *) j);
   return k;


### PR DESCRIPTION
This pull request makes some fairly minor changes to allow *hydrotrend* to build on Windows. Nothing should change for Linux and Mac. Because Windows doesn't have *getopt*, the command line interface is slightly different and more limited. On Windows,
```bash
$ hydrotrend [in_folder [out_folder]]
```
If *in_folder* isn't provided, the current directory is used. Likewise, if *out_folder* isn't provided, output files are written into the current directory.