### PR TITLE
Fix divide-by-zero error in hydrosnow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.6)
 
 project( hydrotrend )
 
+set(CMAKE_MACOSX_RPATH 1)
+
 option (WITH_PYTHON_BINDINGS "Build Python bindings" OFF)
 option (WITH_CTEST "Use CTest to build tests" OFF)
 

--- a/bmi.h
+++ b/bmi.h
@@ -1,5 +1,5 @@
-#ifndef BMI_H_INCLUDED
-#define BMI_H_INCLUDED
+#ifndef BMI_H
+#define BMI_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -9,65 +9,74 @@ extern "C" {
 #define BMI_FAILURE (1)
 
 #define BMI_MAX_UNITS_NAME (2048)
+#define BMI_MAX_TYPE_NAME (2048)
 #define BMI_MAX_COMPONENT_NAME (2048)
 #define BMI_MAX_VAR_NAME (2048)
 
 
-typedef struct {
-  void * self;
+typedef struct BMI_Model {
+  void *data;
 
-  int (* initialize)(const char *, void**);
-  int (* update)(void*);
-  int (* update_until)(void *, double);
-  int (* update_frac)(void *, double);
-  int (* finalize)(void *);
-  int (* run_model)(void *);
+  /* Initialize, run, finalize (IRF) */
+  int (*initialize)(struct BMI_Model *self, const char *config_file);
+  int (*update)(struct BMI_Model *self);
+  int (*update_until)(struct BMI_Model *self, double then);
+  int (*finalize)(struct BMI_Model *self);
 
-  int (* get_component_name)(void *, char *);
-  int (* get_input_var_name_count)(void *, int *);
-  int (* get_output_var_name_count)(void *, int *);
-  int (* get_input_var_names)(void *, char **);
-  int (* get_output_var_names)(void *, char **);
+  /* Exchange items */
+  int (*get_component_name)(struct BMI_Model *self, char *name);
+  int (*get_input_item_count)(struct BMI_Model *self, int *count);
+  int (*get_output_item_count)(struct BMI_Model *self, int *count);
+  int (*get_input_var_names)(struct BMI_Model *self, char **names);
+  int (*get_output_var_names)(struct BMI_Model *self, char **names);
 
-  int (* get_var_grid)(void *, const char *, int *);
-  int (* get_var_type)(void *, const char *, char *);
-  int (* get_var_units)(void *, const char *, char *);
-  int (* get_var_itemsize)(void *, const char *, int *);
-  int (* get_var_nbytes)(void *, const char *, int *);
-  int (* get_var_location)(void *, const char *, char *);
-  int (* get_current_time)(void *, double *);
-  int (* get_start_time)(void *, double *);
-  int (* get_end_time)(void *, double *);
-  int (* get_time_units)(void *, char *);
-  int (* get_time_step)(void *, double *);
+  /* Variable information */
+  int (*get_var_grid)(struct BMI_Model *self, const char *name, int *grid);
+  int (*get_var_type)(struct BMI_Model *self, const char *name, char *type);
+  int (*get_var_units)(struct BMI_Model *self, const char *name, char *units);
+  int (*get_var_itemsize)(struct BMI_Model *self, const char *name, int *size);
+  int (*get_var_nbytes)(struct BMI_Model *self, const char *name, int *nbytes);
+  int (*get_var_location)(struct BMI_Model *self, const char *name, char *location);
 
-  /* Variable getter and setter functions */
-  int (* get_value)(void *, const char *, void *);
-  int (* get_value_ptr)(void *, const char *, void **);
-  int (* get_value_at_indices)(void *, const char *, void *, int *, int);
+  /* Time information */
+  int (*get_current_time)(struct BMI_Model *self, double *time);
+  int (*get_start_time)(struct BMI_Model *self, double *time);
+  int (*get_end_time)(struct BMI_Model *self, double *time);
+  int (*get_time_units)(struct BMI_Model *self, char *units);
+  int (*get_time_step)(struct BMI_Model *self, double *time_step);
 
-  int (* set_value)(void *, const char *, void *);
-  int (* set_value_ptr)(void *, const char *, void **);
-  int (* set_value_at_indices)(void *, const char *, int *, int, void *);
+  /* Getters */
+  int (*get_value)(struct BMI_Model *self, const char *name, void *dest);
+  int (*get_value_ptr)(struct BMI_Model *self, const char *name, void **dest_ptr);
+  int (*get_value_at_indices)(struct BMI_Model *self, const char *name, void *dest, int *inds, int count);
 
-  /* Grid information functions */
-  int (* get_grid_rank)(void *, int, int *);
-  int (* get_grid_size)(void *, int, int *);
-  int (* get_grid_type)(void *, int, char *);
-  int (* get_grid_shape)(void *, int, int *);
-  int (* get_grid_spacing)(void *, int, double *);
-  int (* get_grid_origin)(void *, int, double *);
+  /* Setters */
+  int (*set_value)(struct BMI_Model *self, const char *name, void *src);
+  int (*set_value_at_indices)(struct BMI_Model *self, const char *name, int *inds, int count, void *src);
 
-  int (* get_grid_x)(void *, int, double *);
-  int (* get_grid_y)(void *, int, double *);
-  int (* get_grid_z)(void *, int, double *);
+  /* Grid information */
+  int (*get_grid_rank)(struct BMI_Model *self, int grid, int *rank);
+  int (*get_grid_size)(struct BMI_Model *self, int grid, int *size);
+  int (*get_grid_type)(struct BMI_Model *self, int grid, char *type);
 
-  int (* get_grid_face_count)(void *, int, int *);
-  int (* get_grid_point_count)(void *, int, int *);
-  int (* get_grid_vertex_count)(void *, int, int *);
+  /* Uniform rectilinear */
+  int (*get_grid_shape)(struct BMI_Model *self, int grid, int *shape);
+  int (*get_grid_spacing)(struct BMI_Model *self, int grid, double *spacing);
+  int (*get_grid_origin)(struct BMI_Model *self, int grid, double *origin);
 
-  int (* get_grid_connectivity)(void *, int, int *);
-  int (* get_grid_offset)(void *, int, int *);
+  /* Non-uniform rectilinear, curvilinear */
+  int (*get_grid_x)(struct BMI_Model *self, int grid, double *x);
+  int (*get_grid_y)(struct BMI_Model *self, int grid, double *y);
+  int (*get_grid_z)(struct BMI_Model *self, int grid, double *z);
+
+  /* Unstructured */
+  int (*get_grid_node_count)(struct BMI_Model *self, int grid, int *count);
+  int (*get_grid_edge_count)(struct BMI_Model *self, int grid, int *count);
+  int (*get_grid_face_count)(struct BMI_Model *self, int grid, int *count);
+  int (*get_grid_edge_nodes)(struct BMI_Model *self, int grid, int *edge_nodes);
+  int (*get_grid_face_edges)(struct BMI_Model *self, int grid, int *face_edges);
+  int (*get_grid_face_nodes)(struct BMI_Model *self, int grid, int *face_nodes);
+  int (*get_grid_nodes_per_face)(struct BMI_Model *self, int grid, int *nodes_per_face);
 } BMI_Model;
 
 

--- a/bmi_hydrotrend.c
+++ b/bmi_hydrotrend.c
@@ -29,7 +29,7 @@ _str_strip(char *str) {
 
 
 static int
-get_component_name (void *self, char * name)
+get_component_name (BMI_Model *self, char * name)
 {
     strncpy (name, "hydrotrend", BMI_MAX_COMPONENT_NAME);
     return BMI_SUCCESS;
@@ -43,7 +43,7 @@ static const char *input_var_names[INPUT_VAR_NAME_COUNT] = {
 
 
 static int
-get_input_var_name_count(void *self, int *count)
+get_input_var_name_count(BMI_Model *self, int *count)
 {
     *count = INPUT_VAR_NAME_COUNT;
     return BMI_SUCCESS;
@@ -51,7 +51,7 @@ get_input_var_name_count(void *self, int *count)
 
 
 static int
-get_input_var_names(void *self, char **names)
+get_input_var_names(BMI_Model *self, char **names)
 {
     int i;
     for (i=0; i<INPUT_VAR_NAME_COUNT; i++) {
@@ -78,7 +78,7 @@ static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
 
 
 static int
-get_output_var_name_count(void *self, int *count)
+get_output_var_name_count(BMI_Model *self, int *count)
 {
     *count = OUTPUT_VAR_NAME_COUNT;
     return BMI_SUCCESS;
@@ -86,7 +86,7 @@ get_output_var_name_count(void *self, int *count)
 
 
 static int
-get_output_var_names(void *self, char **names)
+get_output_var_names(BMI_Model *self, char **names)
 {
     int i;
     for (i=0; i<OUTPUT_VAR_NAME_COUNT; i++) {
@@ -97,7 +97,7 @@ get_output_var_names(void *self, char **names)
 
 
 static int
-get_start_time(void * self, double *time)
+get_start_time(BMI_Model * self, double *time)
 {
     *time = 0;
     return BMI_SUCCESS;
@@ -105,23 +105,23 @@ get_start_time(void * self, double *time)
 
 
 static int
-get_end_time(void * self, double *time)
+get_end_time(BMI_Model * self, double *time)
 { /* Implement this: Set end time */
-    *time  = ((state*)self)->n_days;
+    *time  = ((HydrotrendData*)self->data)->n_days;
     return BMI_SUCCESS;
 }
 
 
 static int
-get_current_time(void * self, double *time)
+get_current_time(BMI_Model * self, double *time)
 { /* Implement this: Set current time */
-    *time = ((state*)self)->day;
+    *time = ((HydrotrendData*)self->data)->day;
     return BMI_SUCCESS;
 }
 
 
 static int
-get_time_step(void * self, double *dt)
+get_time_step(BMI_Model * self, double *dt)
 { /* Implement this: Set time step */
     *dt = 1.;
     return BMI_SUCCESS;
@@ -129,7 +129,7 @@ get_time_step(void * self, double *dt)
 
 
 static int
-get_time_units(void * self, char *units)
+get_time_units(BMI_Model * self, char *units)
 {
     strncpy(units, "d", BMI_MAX_UNITS_NAME);
     return BMI_SUCCESS;
@@ -137,15 +137,12 @@ get_time_units(void * self, char *units)
 
 
 static int
-initialize(const char * file, void **handle)
+initialize(BMI_Model *self, const char * file)
 { /* Implement this: Create and initialize a model handle */
-  if (handle) {
-    state * self = NULL;
+  if (self) {
     char *in_dir = NULL;
     char *prefix = NULL;
     char *out_dir = NULL;
-
-    *handle = NULL;
 
     if (file && file[0] != '\0') {
       FILE * fp = fopen (file, "r");
@@ -162,6 +159,7 @@ initialize(const char * file, void **handle)
         if (fgets (args, 2048, fp)==args) {
           out_dir = _str_strip (strdup (args));
         }
+        fclose(fp);
       }
       else
           return BMI_FAILURE;
@@ -173,57 +171,54 @@ initialize(const char * file, void **handle)
     }
 
     if (in_dir && prefix && out_dir) {
-      self = hydro_initialize (in_dir, prefix, out_dir);
+      hydro_initialize((HydrotrendData*)self->data, in_dir, prefix, out_dir);
     }
-
-    if (self)
-      *handle = (void*)self;
-    else
-      return BMI_FAILURE;
   }
+  else
+    return BMI_FAILURE;
 
   return BMI_SUCCESS;
 }
 
 
 static int
-update_frac(void * self, double f)
+update_frac(BMI_Model * self, double f)
 { /* Implement this: Update for a fraction of a time step */
     return BMI_FAILURE;
 }
 
 
 static int
-update(void * self)
+update(BMI_Model * self)
 {
     double day;
 
-    if (get_current_time(self, &day) == BMI_FAILURE)
+    if (self->get_current_time(self, &day) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    hydro_run((state*)self, day + 1.);
+    hydro_run((HydrotrendData*)self->data, day + 1.);
 
     return BMI_SUCCESS;
 }
 
 
 static int
-update_until(void * self, double then)
+update_until(BMI_Model * self, double then)
 {
     double dt;
     double now;
 
-    if (get_time_step(self, &dt) == BMI_FAILURE)
+    if (self->get_time_step(self, &dt) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    if (get_current_time(self, &now) == BMI_FAILURE)
+    if (self->get_current_time(self, &now) == BMI_FAILURE)
         return BMI_FAILURE;
 
     {
         int n;
         const double n_steps = (then - now) / dt;
         for (n=0; n<(int)n_steps; n++) {
-            if (update(self) == BMI_FAILURE)
+            if (self->update(self) == BMI_FAILURE)
                 return BMI_FAILURE;
         }
 /*
@@ -237,53 +232,17 @@ update_until(void * self, double then)
 
 
 static int
-finalize(void * self)
+finalize(BMI_Model * self)
 { /* Implement this: Clean up */
-    hydro_finalize ((state*)self);
+    hydro_finalize ((HydrotrendData*)self->data);
     return BMI_SUCCESS;
 }
 
 
 static int
-get_grid_type(void *self, int id, char *type)
+get_var_grid(BMI_Model *self, const char *name, int *grid)
 {
-    if (id == 0) {
-        strncpy(type, "scalar", 2048);
-    } else {
-        type[0] = '\0'; return BMI_FAILURE;
-    }
-    return BMI_SUCCESS;
-}
-
-
-static int
-get_grid_rank(void *self, int id, int *rank)
-{
-    if (id == 0) {
-        *rank = 0;
-    } else {
-        *rank = -1; return BMI_FAILURE;
-    }
-    return BMI_SUCCESS;
-}
-
-
-static int
-get_grid_size(void *self, int id, int *size)
-{
-    int rank;
-    if (get_grid_rank(self, id, &rank) == BMI_FAILURE)
-        return BMI_FAILURE;
-
-    *size = 1;
-
-    return BMI_SUCCESS;
-}
-
-
-static int
-get_var_grid(void *self, const char *name, int *grid)
-{
+    return BMI_FAILURE;
     if (strcmp(name, "atmosphere_bottom_air__domain_mean_of_temperature") == 0) {
         *grid = 0;
     } else if (strcmp(name, "channel_exit_water_sediment~suspended__mass_flow_rate") == 0) {
@@ -314,7 +273,7 @@ get_var_grid(void *self, const char *name, int *grid)
 
 
 static int
-get_var_type(void *self, const char *name, char *type)
+get_var_type(BMI_Model *self, const char *name, char *type)
 {
     if (strcmp(name, "atmosphere_bottom_air__domain_mean_of_temperature") == 0) {
         strncpy(type, "double", BMI_MAX_UNITS_NAME);
@@ -346,7 +305,7 @@ get_var_type(void *self, const char *name, char *type)
 
 
 static int
-get_var_units(void *self, const char *name, char *units)
+get_var_units(BMI_Model *self, const char *name, char *units)
 {
     if (strcmp(name, "atmosphere_bottom_air__domain_mean_of_temperature") == 0) {
         strncpy(units, "degree_Celsius", BMI_MAX_UNITS_NAME);
@@ -378,7 +337,7 @@ get_var_units(void *self, const char *name, char *units)
 
 
 static int
-get_var_itemsize(void *self, const char *name, int *itemsize)
+get_var_itemsize(BMI_Model *self, const char *name, int *itemsize)
 {
     if (strcmp(name, "atmosphere_bottom_air__domain_mean_of_temperature") == 0) {
         *itemsize = sizeof(double);
@@ -410,58 +369,52 @@ get_var_itemsize(void *self, const char *name, int *itemsize)
 
 
 static int
-get_var_nbytes(void *self, const char *name, int *nbytes)
+get_var_nbytes(BMI_Model *self, const char *name, int *nbytes)
 {
-    int id, size, itemsize;
+    int itemsize;
 
-    if (get_var_grid(self, name, &id) == BMI_FAILURE)
+    if (self->get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    if (get_grid_size(self, id, &size) == BMI_FAILURE)
-        return BMI_FAILURE;
-
-    if (get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
-        return BMI_FAILURE;
-
-    *nbytes = itemsize * size;
+    *nbytes = itemsize;
 
     return BMI_SUCCESS;
 }
 
 
 static int
-get_var_location(void *self, const char *name, char *loc)
+get_var_location(BMI_Model *self, const char *name, char *loc)
 {
-    strncpy(loc, "grid", BMI_MAX_VAR_NAME);
+    strncpy(loc, "none", BMI_MAX_VAR_NAME);
     return BMI_SUCCESS;
 }
 
 
 static int
-get_value_ptr(void *self, const char *name, void **dest)
+get_value_ptr(BMI_Model *self, const char *name, void **dest)
 {
     if (strcmp(name, "atmosphere_bottom_air__domain_mean_of_temperature") == 0) {
-        *dest = hydro_get_temperature_ptr(self);
+        *dest = hydro_get_temperature_ptr(self->data);
     } else if (strcmp(name, "channel_exit_water_sediment~suspended__mass_flow_rate") == 0) {
-        *dest = hydro_get_sediment_discharge_ptr(self);
+        *dest = hydro_get_sediment_discharge_ptr(self->data);
     } else if (strcmp(name,"channel_exit_water_sediment~suspended__mass_concentration") == 0) {
-        *dest = hydro_get_sediment_concentration_ptr(self);
+        *dest = hydro_get_sediment_concentration_ptr(self->data);
     } else if (strcmp(name, "channel_exit_water_flow__speed") == 0) {
-        *dest = hydro_get_velocity_ptr(self);
+        *dest = hydro_get_velocity_ptr(self->data);
     } else if (strcmp(name, "channel_entrance_water_sediment~bedload__mass_flow_rate") == 0) {
-        *dest = hydro_get_bedload_flux_ptr(self);
+        *dest = hydro_get_bedload_flux_ptr(self->data);
     } else if (strcmp(name, "channel_exit_water__volume_flow_rate") == 0) {
-        *dest = hydro_get_water_discharge_ptr(self);
+        *dest = hydro_get_water_discharge_ptr(self->data);
     } else if (strcmp(name, "channel_exit_water_x-section__width") == 0) {
-        *dest = hydro_get_width_ptr(self);
+        *dest = hydro_get_width_ptr(self->data);
     } else if (strcmp(name, "channel_exit_water_x-section__depth") == 0) {
-        *dest = hydro_get_depth_ptr(self);
+        *dest = hydro_get_depth_ptr(self->data);
     } else if (strcmp(name, "channel_entrance_water__volume_flow_rate") == 0) {
-        *dest = hydro_get_water_discharge_ptr(self);
+        *dest = hydro_get_water_discharge_ptr(self->data);
     } else if (strcmp(name, "atmosphere_water__domain_mean_of_precipitation_leq-volume_flux") == 0) {
-        *dest = hydro_get_precipitation_ptr(self);
+        *dest = hydro_get_precipitation_ptr(self->data);
     } else if (strcmp(name, "channel_exit_water_sediment~bedload__mass_flow_rate") == 0) {
-        *dest = hydro_get_bedload_flux_ptr(self);
+        *dest = hydro_get_bedload_flux_ptr(self->data);
     } else {
         *dest = NULL; return BMI_FAILURE;
     }
@@ -474,15 +427,15 @@ get_value_ptr(void *self, const char *name, void **dest)
 
 
 int
-get_value(void * self, const char * name, void *dest)
+get_value(BMI_Model * self, const char * name, void *dest)
 {
     void *src = NULL;
     int nbytes = 0;
 
-    if (get_value_ptr (self, name, &src) == BMI_FAILURE)
+    if (self->get_value_ptr (self, name, &src) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    if (get_var_nbytes (self, name, &nbytes) == BMI_FAILURE)
+    if (self->get_var_nbytes (self, name, &nbytes) == BMI_FAILURE)
         return BMI_FAILURE;
 
     memcpy(dest, src, nbytes);
@@ -492,16 +445,16 @@ get_value(void * self, const char * name, void *dest)
 
 
 static int
-get_value_at_indices (void *self, const char *name, void *dest,
+get_value_at_indices (BMI_Model *self, const char *name, void *dest,
     int * inds, int len)
 {
     void *src = NULL;
     int itemsize = 0;
 
-    if (get_value_ptr(self, name, &src) == BMI_FAILURE)
+    if (self->get_value_ptr(self, name, &src) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    if (get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
+    if (self->get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
         return BMI_FAILURE;
 
     { /* Copy the data */
@@ -519,15 +472,15 @@ get_value_at_indices (void *self, const char *name, void *dest,
 
 
 static int
-set_value (void *self, const char *name, void *array)
+set_value (BMI_Model *self, const char *name, void *array)
 {
     void * dest = NULL;
     int nbytes = 0;
 
-    if (get_value_ptr(self, name, &dest) == BMI_FAILURE)
+    if (self->get_value_ptr(self, name, &dest) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    if (get_var_nbytes(self, name, &nbytes) == BMI_FAILURE)
+    if (self->get_var_nbytes(self, name, &nbytes) == BMI_FAILURE)
         return BMI_FAILURE;
 
     memcpy (dest, array, nbytes);
@@ -537,16 +490,16 @@ set_value (void *self, const char *name, void *array)
 
 
 static int
-set_value_at_indices (void *self, const char *name, int * inds, int len,
+set_value_at_indices (BMI_Model *self, const char *name, int * inds, int len,
     void *src)
 {
     void * to = NULL;
     int itemsize = 0;
 
-    if (get_value_ptr (self, name, &to) == BMI_FAILURE)
+    if (self->get_value_ptr (self, name, &to) == BMI_FAILURE)
         return BMI_FAILURE;
 
-    if (get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
+    if (self->get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
         return BMI_FAILURE;
 
     { /* Copy the data */
@@ -565,24 +518,25 @@ set_value_at_indices (void *self, const char *name, int * inds, int len,
 BMI_Model*
 register_bmi_hydrotrend(BMI_Model *model)
 {
-    model->self = NULL;
+    model->data = (void*)new_data();
 
     model->initialize = initialize;
     model->update = update;
     model->update_until = update_until;
-    model->update_frac = update_frac;
+    // model->update_frac = update_frac;
     model->finalize = finalize;
-    model->run_model = NULL;
+    // model->run_model = NULL;
 
     model->get_component_name = get_component_name;
-    model->get_input_var_name_count = get_input_var_name_count;
-    model->get_output_var_name_count = get_output_var_name_count;
+    model->get_input_item_count = get_input_var_name_count;
+    model->get_output_item_count = get_output_var_name_count;
     model->get_input_var_names = get_input_var_names;
     model->get_output_var_names = get_output_var_names;
 
     model->get_var_grid = get_var_grid;
     model->get_var_type = get_var_type;
     model->get_var_units = get_var_units;
+    model->get_var_itemsize = get_var_itemsize;
     model->get_var_nbytes = get_var_nbytes;
     model->get_var_location = get_var_location;
     model->get_current_time = get_current_time;
@@ -596,12 +550,14 @@ register_bmi_hydrotrend(BMI_Model *model)
     model->get_value_at_indices = get_value_at_indices;
 
     model->set_value = set_value;
-    model->set_value_ptr = NULL;
+    // model->set_value_ptr = NULL;
     model->set_value_at_indices = set_value_at_indices;
 
-    model->get_grid_rank = get_grid_rank;
-    model->get_grid_size = get_grid_size;
-    model->get_grid_type = get_grid_type;
+    model->get_grid_rank = NULL;
+    model->get_grid_size = NULL;
+    model->get_grid_type = NULL;
+
+    model->get_grid_node_count = NULL;
 
     return model;
 }

--- a/hydrorandomsediment.c
+++ b/hydrorandomsediment.c
@@ -44,7 +44,7 @@ hydrorandomsediment ()
  *  Local Variables
  *-------------------*/
   float hydroran2sediment (long *idum);
-  float fac, rsq, v1, v2, *unival;
+  float fac, rsq, v1, v2;
   double rsum;
   int err, ii, jj;
   err = 0;
@@ -64,10 +64,6 @@ hydrorandomsediment ()
   if (yr == syear[ep])
     rnseed = -INIT_RAN_NUM_SEED - 10 * ep;
 
-  unival = malloc1d (2 * nyears[ep], float);
-  for (ii = 0; ii < 2 * nyears[ep]; ii++)
-    unival[ii] = hydroran2sediment (&rnseed);
-
 /*
  *  Next generate Gaussian distributed deviates.
  *  The routine returns two random numbers for each pass,
@@ -75,17 +71,20 @@ hydrorandomsediment ()
  *  GASDEV, From "Numerical Recipes in C", p.289, 2nd ed.
  */
   jj = 0;
-  for (ii = 0; ii < nyears[ep] - 1; ii += 2)
+  for (ii = 0; ii < nyears[ep]; ii += 2)
     {
       do
         {
-          v1 = 2.0 * unival[jj] - 1.0;
-          v2 = 2.0 * unival[jj + 1] - 1.0;
+          v1 = 2.0 * hydroran2sediment(&rnseed) - 1.0;
+          v2 = 2.0 * hydroran2sediment(&rnseed) - 1.0;
+
           rsq = v1 * v1 + v2 * v2;
           jj += 2;
         }
       while (rsq >= 1.0 || rsq == 0.0);
       fac = sqrt (-2.0 * log (rsq) / rsq);
+
+      // Note that the length of ranarraysediment is longer than nyears[ep] + 1
       ranarraysediment[ii] = (double) v1 *fac;
       ranarraysediment[ii + 1] = (double) v2 *fac;
     }
@@ -102,6 +101,5 @@ hydrorandomsediment ()
       rmax = mx (rmax, ranarraysediment[ii]);
       rsum += ranarraysediment[ii];
     }
-  freematrix1D ((void *) unival);
   return (err);
 }                               /* end of HydroRandomsediment */

--- a/hydrosnow.c
+++ b/hydrosnow.c
@@ -245,7 +245,7 @@ hydrosnow ()
   Mout = Mgw + Mnival + Enivalannual * totalarea[ep] + Msnowend + Mwrapout;
   Minput = MPnival + Mwrapin + Msnowstart;
 
-  if ((fabs (Mout - Minput) / Minput) > masscheck)
+  if (Minput > 0.0 && (fabs (Mout - Minput) / Minput) > masscheck)
     {
       fprintf (stderr, "\nERROR in HydroSnow: \n");
       fprintf (stderr, "  Mass Balance error: Mout != Minput \n\n");

--- a/hydrotrend_irf.h
+++ b/hydrotrend_irf.h
@@ -18,32 +18,35 @@ typedef struct
   double *qb;
   double *temp;
   double *prec;
-} state;
+} HydrotrendData;
 
 
-extern state * hydro_initialize (char* in_dir, char *in_file_prefix,
-                                 char *out_dir);
-extern state * hydro_run (state * s, double time);
-extern state * hydro_finalize (state * s);
+extern HydrotrendData* new_data();
+extern void initialize_data(HydrotrendData* data, int n_days);
 
-extern double * hydro_get_velocity_ptr (state * self);
-extern double hydro_get_velocity (state * self);
-extern double * hydro_get_width_ptr (state * self);
-extern double hydro_get_width (state * self);
-extern double * hydro_get_depth_ptr (state * self);
-extern double hydro_get_depth (state * self);
-extern double * hydro_get_water_discharge_ptr (state * self);
-extern double hydro_get_water_discharge (state * self);
-extern double * hydro_get_sediment_discharge_ptr (state * self);
-extern double hydro_get_sediment_discharge (state * self);
-extern double * hydro_get_sediment_concentration_ptr(state * self);
-extern double hydro_get_sediment_concentration(state * self);
-extern double * hydro_get_bedload_flux_ptr (state * self);
-extern double hydro_get_bedload_flux (state * self);
-extern double * hydro_get_precipitation_ptr (state * self);
-extern double hydro_get_precipitation (state * self);
-extern double * hydro_get_temperature_ptr (state * self);
-extern double hydro_get_temperature (state * self);
+extern void hydro_initialize(HydrotrendData *self, char* in_dir, char* in_file_prefix, char* out_dir);
+// extern HydrotrendData * hydro_initialize (char* in_dir, char *in_file_prefix, char *out_dir);
+extern HydrotrendData * hydro_run (HydrotrendData * s, double time);
+extern HydrotrendData * hydro_finalize (HydrotrendData * s);
+
+extern double * hydro_get_velocity_ptr (HydrotrendData * self);
+extern double hydro_get_velocity (HydrotrendData * self);
+extern double * hydro_get_width_ptr (HydrotrendData * self);
+extern double hydro_get_width (HydrotrendData * self);
+extern double * hydro_get_depth_ptr (HydrotrendData * self);
+extern double hydro_get_depth (HydrotrendData * self);
+extern double * hydro_get_water_discharge_ptr (HydrotrendData * self);
+extern double hydro_get_water_discharge (HydrotrendData * self);
+extern double * hydro_get_sediment_discharge_ptr (HydrotrendData * self);
+extern double hydro_get_sediment_discharge (HydrotrendData * self);
+extern double * hydro_get_sediment_concentration_ptr(HydrotrendData * self);
+extern double hydro_get_sediment_concentration(HydrotrendData * self);
+extern double * hydro_get_bedload_flux_ptr (HydrotrendData * self);
+extern double hydro_get_bedload_flux (HydrotrendData * self);
+extern double * hydro_get_precipitation_ptr (HydrotrendData * self);
+extern double hydro_get_precipitation (HydrotrendData * self);
+extern double * hydro_get_temperature_ptr (HydrotrendData * self);
+extern double hydro_get_temperature (HydrotrendData * self);
 
 #if defined(__cplusplus)
 }

--- a/hydrotrend_main.c
+++ b/hydrotrend_main.c
@@ -54,10 +54,12 @@ main (int argc, char **argv)
 
     register_bmi_hydrotrend(model);
 
-    model->self = hydro_initialize(in_dir, in_prefix, out_dir);
+    hydro_initialize(model->data, in_dir, in_prefix, out_dir);
 
-    model->update_until(model->self, 10.5);
-    model->finalize(model->self);
+    model->update_until(model, 10.5);
+    model->finalize(model);
+
+    free(model);
   }
 
   fprint_current_time( stdout, "Stop" );

--- a/hydroweather.c
+++ b/hydroweather.c
@@ -308,7 +308,8 @@ cost_fcn (double *x, int n)
       else
         j[i] = 0;
       if (i > daystrm[jj])
-        k += fabs (j[i - 1] - j[i]);
+        k += abs (j[i - 1] - j[i]);
+        // k += fabs (j[i - 1] - j[i]);
     }
   freematrix1D ((void *) j);
   return k;


### PR DESCRIPTION
This pull request fixes a divide-by-zero error in *hydrosnow* that caused a segmentation fault or floating point exception, depending on the system. A mass-balance check is done at the end of *hydrosnow* and if `Minput` is zero, which happens to be the denominator, a floating-point error may be triggered.